### PR TITLE
feat: add new address type identifiers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ endif()
 target_common_warnings(ULF_DCC_EIN INTERFACE)
 
 if(NOT TARGET DCC::DCC)
-  cpmaddpackage("gh:ZIMO-Elektronik/DCC@0.39.0")
+  cpmaddpackage("gh:ZIMO-Elektronik/DCC@0.40.1")
 endif()
 
 target_link_libraries(ULF_DCC_EIN INTERFACE DCC::DCC)

--- a/README.md
+++ b/README.md
@@ -39,20 +39,20 @@ The command can optionally be answered with a string of the pattern `senddcc [a-
 | p                                 | response byte indicates current buffer level in packets |
 
 ### sendbidi
-The string of the `sendbidi` command follows the pattern `sendbidi [ubsalrtei][0-9a-fA-F]{4}( [0-9a-fA-F]{2}){8}\r`. In addition to the hex ASCII coded datagram, the command also contains the address belonging to the datagram. Since [DCC](https://github.com/ZIMO-Elektronik/DCC) addresses are not unique, an associated identifier that determines the address type must also be included.
+The string of the `sendbidi` command follows the pattern `sendbidi [ubsaxlrtei][0-9a-fA-F]{4}( [0-9a-fA-F]{2}){8}\r`. In addition to the hex ASCII coded datagram, the command also contains the address belonging to the datagram. Since [DCC](https://github.com/ZIMO-Elektronik/DCC) addresses are not unique, an associated identifier that determines the address type must also be included.
 
 | Address Preceding Character | [DCC](https://github.com/ZIMO-Elektronik/DCC) Address Type   |
 | --------------------------- | ------------------------------------------------------------ |
 | u                           | Unknown or service                                           |
 | b                           | Broadcast                                                    |
-| s                           | Short                                                        |
-| a                           | Accessory                                                    |
-| l                           | Long                                                         |
+| s                           | Basic loco (short)                                           |
+| a                           | Basic accessory                                              |
+| x                           | Extended accessory                                           |
+| l                           | Extended loco (long)                                         |
 | r                           | Reserved                                                     |
 | t                           | Data transfer                                                |
 | e                           | Automatic logon                                              |
 | i                           | Idle or system                                               |
-
 
 > [!IMPORTANT]  
 > Bytes inside a `sendbidi` string where no data was received must be filled with zeros. For example, an answer that does not include channel 1 might look like this.
@@ -70,13 +70,13 @@ This library is meant to be consumed with CMake.
 
 ```cmake
 # Either by including it with CPM
-cpmaddpackage("gh:ZIMO-Elektronik/ULF_DCC_EIN@0.3.2")
+cpmaddpackage("gh:ZIMO-Elektronik/ULF_DCC_EIN@0.4.0")
 
 # or the FetchContent module
 FetchContent_Declare(
   ULF_DCC_EIN
   GIT_REPOSITORY "https://github.com/ZIMO-Elektronik/ULF_DCC_EIN"
-  GIT_TAG v0.3.2)
+  GIT_TAG v0.4.0)
 
 target_link_libraries(YourTarget INTERFACE ULF::DCC_EIN)
 ```
@@ -126,7 +126,7 @@ A `sendbidi` string can be generated from an `AddressedDatagram` via `addressed_
 ```cpp
 // Create sendbidi string from address and datagram
 ulf::dcc_ein::AddressedDatagram addressed_datagram{
-  .addr = {.value = 3u, .type = dcc::Address::Short},
+  .addr = {.value = 3u, .type = dcc::Address::BasicLoco},
   .datagram = {0xA3u, 0xACu, 0x55u, 0xB1u, 0xD2u, 0x5Au, 0xACu, 0x9Au}};
 auto sendbidi_str{
   ulf::dcc_ein::addressed_datagram2sendbidi_str(addressed_datagram)};

--- a/examples/basics/main.cpp
+++ b/examples/basics/main.cpp
@@ -37,7 +37,7 @@ void senddcc_str2packet(auto&& senddcc_str) {
 auto addressed_datagram2sendbidi_str() {
   // Create sendbidi string from address and datagram
   ulf::dcc_ein::AddressedDatagram addressed_datagram{
-    .addr = {.value = 3u, .type = dcc::Address::Short},
+    .addr = {.value = 3u, .type = dcc::Address::BasicLoco},
     .datagram = {0xA3u, 0xACu, 0x55u, 0xB1u, 0xD2u, 0x5Au, 0xACu, 0x9Au}};
   auto sendbidi_str{
     ulf::dcc_ein::addressed_datagram2sendbidi_str(addressed_datagram)};

--- a/include/ulf/dcc_ein/addressed_datagram2sendbidi_str.hpp
+++ b/include/ulf/dcc_ein/addressed_datagram2sendbidi_str.hpp
@@ -23,7 +23,7 @@ namespace ulf::dcc_ein {
 /// Convert addressed datagram to sendbidi string
 ///
 /// The returned string will have the pattern
-/// 'sendbidi [ubsalrtei][0-9a-f]{4}( [0-9a-f]{2}){8}\r'. This string is sent
+/// 'sendbidi [ubsaxlrtei][0-9a-f]{4}( [0-9a-f]{2}){8}\r'. This string is sent
 /// when a BiDi datagram has been received.
 ///
 /// \param  addr      Address
@@ -42,9 +42,10 @@ addressed_datagram2sendbidi_str(AddressedDatagram const& addressed_datagram) {
   switch (addr.type) {
     case dcc::Address::UnknownService: *first++ = 'u'; break;
     case dcc::Address::Broadcast: *first++ = 'b'; break;
-    case dcc::Address::Short: *first++ = 's'; break;
-    case dcc::Address::Accessory: *first++ = 'a'; break;
-    case dcc::Address::Long: *first++ = 'l'; break;
+    case dcc::Address::BasicLoco: *first++ = 's'; break;
+    case dcc::Address::BasicAccessory: *first++ = 'a'; break;
+    case dcc::Address::ExtendedAccessory: *first++ = 'x'; break;
+    case dcc::Address::ExtendedLoco: *first++ = 'l'; break;
     case dcc::Address::Reserved: *first++ = 'r'; break;
     case dcc::Address::DataTransfer: *first++ = 't'; break;
     case dcc::Address::AutomaticLogon: *first++ = 'e'; break;

--- a/include/ulf/dcc_ein/sendbidi_str2addressed_datagram.hpp
+++ b/include/ulf/dcc_ein/sendbidi_str2addressed_datagram.hpp
@@ -44,9 +44,10 @@ sendbidi_str2addressed_datagram(std::string_view str) {
   switch (str[size(sendbidi_prefix)]) {
     case 'u': addr.type = dcc::Address::UnknownService; break;
     case 'b': addr.type = dcc::Address::Broadcast; break;
-    case 's': addr.type = dcc::Address::Short; break;
-    case 'a': addr.type = dcc::Address::Accessory; break;
-    case 'l': addr.type = dcc::Address::Long; break;
+    case 's': addr.type = dcc::Address::BasicLoco; break;
+    case 'a': addr.type = dcc::Address::BasicAccessory; break;
+    case 'x': addr.type = dcc::Address::ExtendedAccessory; break;
+    case 'l': addr.type = dcc::Address::ExtendedLoco; break;
     case 'r': addr.type = dcc::Address::Reserved; break;
     case 't': addr.type = dcc::Address::DataTransfer; break;
     case 'e': addr.type = dcc::Address::AutomaticLogon; break;

--- a/tests/dcc_ein/addressed_datagram2sendbidi_str.cpp
+++ b/tests/dcc_ein/addressed_datagram2sendbidi_str.cpp
@@ -4,35 +4,44 @@
 
 using namespace std::literals;
 
-TEST(addressed_datagram2sendbidi_str, short_address) {
+TEST(addressed_datagram2sendbidi_str, basic_loco_address) {
   ulf::dcc_ein::AddressedDatagram addressed_datagram{
-    .addr = {.value = 3u, .type = dcc::Address::Short},
+    .addr = {.value = 3u, .type = dcc::Address::BasicLoco},
     .datagram = {0xF4u, 0x58u, 0x81u, 0x3Bu, 0xC4u, 0x79u, 0xF5u, 0xDFu}};
 
   EXPECT_TRUE(std::ranges::equal(
     ulf::dcc_ein::addressed_datagram2sendbidi_str(addressed_datagram),
     "sendbidi s0003 f4 58 81 3b c4 79 f5 df\r"sv));
 
-  addressed_datagram.addr = {.value = 42u, .type = dcc::Address::Short};
+  addressed_datagram.addr = {.value = 42u, .type = dcc::Address::BasicLoco};
   EXPECT_TRUE(std::ranges::equal(
     ulf::dcc_ein::addressed_datagram2sendbidi_str(addressed_datagram),
     "sendbidi s002a f4 58 81 3b c4 79 f5 df\r"sv));
 }
 
-TEST(addressed_datagram2sendbidi_str, long_address) {
+TEST(addressed_datagram2sendbidi_str, extended_loco_address) {
   ulf::dcc_ein::AddressedDatagram addressed_datagram{
-    .addr = {.value = 4217u, .type = dcc::Address::Long},
+    .addr = {.value = 4217u, .type = dcc::Address::ExtendedLoco},
     .datagram = {0xF4u, 0x58u, 0x81u, 0x3Bu, 0xC4u, 0x79u}};
   EXPECT_TRUE(std::ranges::equal(
     ulf::dcc_ein::addressed_datagram2sendbidi_str(addressed_datagram),
     "sendbidi l1079 f4 58 81 3b c4 79 00 00\r"sv));
 }
 
-TEST(addressed_datagram2sendbidi_str, accessory_address) {
+TEST(addressed_datagram2sendbidi_str, basic_accessory_address) {
   ulf::dcc_ein::AddressedDatagram addressed_datagram{
-    .addr = {.value = 271u, .type = dcc::Address::Accessory},
+    .addr = {.value = 271u, .type = dcc::Address::BasicAccessory},
     .datagram = {0xF4u, 0x58u}};
   EXPECT_TRUE(std::ranges::equal(
     ulf::dcc_ein::addressed_datagram2sendbidi_str(addressed_datagram),
     "sendbidi a010f f4 58 00 00 00 00 00 00\r"sv));
+}
+
+TEST(addressed_datagram2sendbidi_str, extended_accessory_address) {
+  ulf::dcc_ein::AddressedDatagram addressed_datagram{
+    .addr = {.value = 271u, .type = dcc::Address::ExtendedAccessory},
+    .datagram = {0xF4u, 0x58u}};
+  EXPECT_TRUE(std::ranges::equal(
+    ulf::dcc_ein::addressed_datagram2sendbidi_str(addressed_datagram),
+    "sendbidi x010f f4 58 00 00 00 00 00 00\r"sv));
 }

--- a/tests/dcc_ein/sendbidi_str2addressed_datagram.cpp
+++ b/tests/dcc_ein/sendbidi_str2addressed_datagram.cpp
@@ -26,7 +26,7 @@ TEST(sendbidi_str2addressed_datagram, string_does_not_start_with_sendbidi) {
 
 TEST(sendbidi_str2addressed_datagram, address_identifier_wrong) {
   auto d{ulf::dcc_ein::sendbidi_str2addressed_datagram(
-    "sendbidi x002a f4 58 81 3b c4 79 f5 df\r")};
+    "sendbidi z002a f4 58 81 3b c4 79 f5 df\r")};
   EXPECT_FALSE(d);
   EXPECT_EQ(d, std::unexpected(std::errc::invalid_argument));
 }
@@ -37,5 +37,6 @@ TEST(sendbidi_str2addressed_datagram, string_valid) {
   EXPECT_TRUE(d);
   EXPECT_TRUE(*d);
   auto [addr, datagram]{**d};
-  EXPECT_EQ(addr, (dcc::Address{.value = 0x2Au, .type = dcc::Address::Short}));
+  EXPECT_EQ(addr,
+            (dcc::Address{.value = 0x2Au, .type = dcc::Address::BasicLoco}));
 }


### PR DESCRIPTION
Adds

- `dcc::Address::BasicLoco`
- `dcc::Address::BasicAccessory`
- `dcc::Address::ExtendedLoco`
- `dcc::Address::BasicAccessory`

address type identifiers.